### PR TITLE
Remove the useless cutoff variable

### DIFF
--- a/R/calibrate.set.R
+++ b/R/calibrate.set.R
@@ -35,9 +35,6 @@ calibrate.set = function(LR.ss, LR.ds, method = c("raw", "laplace")) {
     n.ds = length(LR.ds)
     n = n.ss + n.ds
     
-    # set an arbitary cutoff to prevent division by zero errors but bodgy this and I'm not too keen on it - however so long as the value is
-    # close to, but less than, 1 it makes little difference cutoff = 0.99999999999999999999999999
-    
     # produce vectors for the indicator function and LRs use convention that 1 signifies same set, and 0 different set
     indicator.array = c(rep(0, length = n.ds), rep(1, length = n.ss))
     LR.array = c(LR.ds, LR.ss)
@@ -72,10 +69,6 @@ calibrate.set = function(LR.ss, LR.ds, method = c("raw", "laplace")) {
     
     # prior odds
     prior.odds = n.ss / n.ds
-    
-    # arbitrarily set a cutoff to prevent division by zero errors when we
-    # calculate the odds not very keen on this - don't think it is needed
-    # calibrated.posterior.probabilities[calibrated.posterior.probabilities > cutoff] = cutoff
     
     log.calibrated.posterior.LRs = log(calibrated.posterior.probabilities/(1 - calibrated.posterior.probabilities)) - log(prior.odds)
     


### PR DESCRIPTION
This variable is not useful in R because the 0.99999999999999999999999999 is rounded to one.
The substitution in the LR array is not useful at all.
Moreover, the division by 0 is not an issue in R (the value is set to +Inf or -Inf depending upon the sign of the division).

This is a non-breaking change regarding the calibration process.