### PR TITLE
Remove the "correction for sorting"

### DIFF
--- a/R/calibrate.set.R
+++ b/R/calibrate.set.R
@@ -27,9 +27,6 @@ calibrate.set = function(LR.ss, LR.ds, method = c("raw", "laplace")) {
     
     method = match.arg(method)
 
-    # correction for sorting - possibly not needed for R's sorting leave it in anyway
-    LR.ss = LR.ss - 1e-06
-    
     # get the lengths of the LR vectors and prior vector
     n.ss = length(LR.ss)
     n.ds = length(LR.ds)


### PR DESCRIPTION
This correction of the LR.ss cause some issues for a set of LR that are overlapping.

If the 1e-06 shift some LR.ss below the LR.ds (changing the order of the
sorted list (ordered.indicies)), the calibration will not be the correct one

This change is breaking (the same data-set before could not yield the same (wrong) calibration function).