### PR TITLE
Remove the test for the method and use the actual length of the ordered.indicator.array

### DIFF
--- a/R/calibrate.set.R
+++ b/R/calibrate.set.R
@@ -45,15 +45,8 @@ calibrate.set = function(LR.ss, LR.ds, method = c("raw", "laplace")) {
         ordered.indicator.array = c(1, 0, ordered.indicator.array, 1, 0)
     }
     
-    
-    # gpava doesn't really care what you send it as the first argument so long as it is ascending and of the appropriate length - here I just
-    # sent an integer array
-    if (method == "raw") {
-        calibrated.set = gpava(1:n, ordered.indicator.array)
-    }
-    if (method == "laplace") {
-        calibrated.set = gpava(1:(n + 4), ordered.indicator.array)
-    }
+    # gpava doesn't really care what you send it as the first argument so long as it is ascending and of the appropriate length
+    calibrated.set = gpava(seq(length(ordered.indicator.array)), ordered.indicator.array)
     
     calibrated.posterior.probabilities = calibrated.set$x
     


### PR DESCRIPTION
This PR refactor the calculation of the length of the ordered.indicator.array used to calibrate with gpava.

Not a breaking change, just a refactor of the gpava() function call